### PR TITLE
Improve rejected returnData

### DIFF
--- a/src/mainProcess.js
+++ b/src/mainProcess.js
@@ -26,7 +26,7 @@ export class PromiseIpcMain {
           case 'success':
             return resolve(returnData);
           case 'failure':
-            return reject(new Error(returnData));
+            return reject(returnData);
           default:
             return reject(new Error(`Unexpected IPC call status "${status}" in ${route}`));
         }
@@ -53,8 +53,9 @@ export class PromiseIpcMain {
           event.sender.send(replyChannel, 'success', results);
         })
         .catch((e) => {
-          const message = e && e.message ? e.message : e;
-          event.sender.send(replyChannel, 'failure', message);
+          event.sender.send(replyChannel, 'failure',
+            e instanceof Error ? e : new Error(e)
+          );
         });
     });
   }

--- a/src/renderer.js
+++ b/src/renderer.js
@@ -25,7 +25,7 @@ export class PromiseIpcRenderer {
           case 'success':
             return resolve(returnData);
           case 'failure':
-            return reject(new Error(returnData));
+            return reject(returnData);
           default:
             return reject(new Error(`Unexpected IPC call status "${status}" in ${route}`));
         }
@@ -52,8 +52,9 @@ export class PromiseIpcRenderer {
           ipcRenderer.send(replyChannel, 'success', results);
         })
         .catch((e) => {
-          const message = e && e.message ? e.message : e;
-          ipcRenderer.send(replyChannel, 'failure', message);
+          ipcRenderer.send(replyChannel, 'failure',
+            e instanceof Error ? e : new Error(e)
+          );
         });
     });
   }

--- a/test/mainProcess-tests.js
+++ b/test/mainProcess-tests.js
@@ -63,7 +63,7 @@ describe('mainProcess', () => {
     it('when listener returns rejected promise, sends failure + error to the renderer', (done) => {
       mainProcess.on(route, () => Promise.reject(new Error('foober')));
       ipcRenderer.once('replyChannel', (event, status, result) => {
-        expect([status, result]).to.eql(['failure', 'foober']);
+        expect([status, result]).to.eql(['failure', new Error('foober')]);
         done();
       });
       ipcRenderer.send(route, 'replyChannel', 'dataArg1');
@@ -72,7 +72,7 @@ describe('mainProcess', () => {
     it('lets listener reject with a simple string', (done) => {
       mainProcess.on(route, () => Promise.reject('goober'));
       ipcRenderer.once('replyChannel', (event, status, result) => {
-        expect([status, result]).to.eql(['failure', 'goober']);
+        expect([status, result]).to.eql(['failure', new Error('goober')]);
         done();
       });
       ipcRenderer.send(route, 'replyChannel', 'dataArg1');
@@ -83,7 +83,7 @@ describe('mainProcess', () => {
         throw new Error('oh no');
       });
       ipcRenderer.once('replyChannel', (event, status, result) => {
-        expect([status, result]).to.eql(['failure', 'oh no']);
+        expect([status, result]).to.eql(['failure', new Error('oh no')]);
         done();
       });
       ipcRenderer.send(route, 'replyChannel', 'dataArg1');
@@ -135,7 +135,7 @@ describe('mainProcess', () => {
     it('rejects with the IPC-passed message on failure', () => {
       const replyChannel = `route#${uuid}`;
       ipcRenderer.once('route', (event) => {
-        event.sender.send(replyChannel, 'failure', 'an error message');
+        event.sender.send(replyChannel, 'failure', new Error('an error message'));
       });
       const promise = mainProcess.send('route', mockWebContents, 'dataArg1', 'dataArg2');
       return expect(promise).to.be.rejectedWith(Error, 'an error message');

--- a/test/renderer-tests.js
+++ b/test/renderer-tests.js
@@ -51,7 +51,7 @@ describe('renderer', () => {
     it('rejects with the IPC-passed message on failure', () => {
       const replyChannel = `route#${uuid}`;
       ipcMain.once('route', (event) => {
-        event.sender.send(replyChannel, 'failure', 'an error message');
+        event.sender.send(replyChannel, 'failure', new Error('an error message'));
       });
       const promise = renderer.send('route', 'dataArg1', 'dataArg2');
       return expect(promise).to.be.rejectedWith(Error, 'an error message');
@@ -141,7 +141,7 @@ describe('renderer', () => {
     it('when listener returns rejected promise, sends failure + error to the main process', (done) => {
       renderer.on(route, () => Promise.reject(new Error('foober')));
       ipcMain.once('replyChannel', (event, status, result) => {
-        expect([status, result]).to.eql(['failure', 'foober']);
+        expect([status, result]).to.eql(['failure', new Error('foober')]);
         done();
       });
       mockWebContents.send(route, 'replyChannel', 'dataArg1');
@@ -150,7 +150,7 @@ describe('renderer', () => {
     it('lets a listener reject with a simple string', (done) => {
       renderer.on(route, () => Promise.reject('goober'));
       ipcMain.once('replyChannel', (event, status, result) => {
-        expect([status, result]).to.eql(['failure', 'goober']);
+        expect([status, result]).to.eql(['failure', new Error('goober')]);
         done();
       });
       mockWebContents.send(route, 'replyChannel', 'dataArg1');
@@ -161,7 +161,7 @@ describe('renderer', () => {
         throw new Error('oh no');
       });
       ipcMain.once('replyChannel', (event, status, result) => {
-        expect([status, result]).to.eql(['failure', 'oh no']);
+        expect([status, result]).to.eql(['failure', new Error('oh no')]);
         done();
       });
       mockWebContents.send(route, 'replyChannel', 'dataArg1');


### PR DESCRIPTION
Hi, @sibnerian!

I am using this library with [axios](https://github.com/axios/axios) .
but, when promise rejected, I can not use custom error data (response, StatusCode, headers, etc...).
This PR will support sending custom errors.