### PR TITLE
fix (typescript): change "on()" parameters to any

### DIFF
--- a/src/base.ts
+++ b/src/base.ts
@@ -10,28 +10,28 @@ type IpcEvent = IpcRendererEvent & IpcMainEvent;
  * This leads to the following verbose overload type for a listener function.
  */
 export type Listener =
-  | { (event?: IpcEvent): void }
-  | { (arg1?: unknown, event?: IpcEvent): void }
-  | { (arg1?: unknown, arg2?: unknown, event?: IpcEvent): void }
-  | { (arg1?: unknown, arg2?: unknown, arg3?: unknown, event?: IpcEvent): void }
+  | { (event?: IpcEvent): Promise<any> | void }
+  | { (arg1: any, event?: IpcEvent): Promise<any> | void }
+  | { (arg1: any, arg2: any, event?: IpcEvent): Promise<any> | void }
+  | { (arg1: any, arg2: any, arg3: any, event?: IpcEvent): Promise<any> | void }
   | {
       (
-        arg1?: unknown,
-        arg2?: unknown,
-        arg3?: unknown,
-        arg4?: unknown,
+        arg1: any,
+        arg2: any,
+        arg3: any,
+        arg4: any,
         event?: IpcEvent,
-      ): void;
+      ): Promise<any> | void;
     }
   | {
       (
-        arg1?: unknown,
-        arg2?: unknown,
-        arg3?: unknown,
-        arg4?: unknown,
-        arg5?: unknown,
+        arg1: any,
+        arg2: any,
+        arg3: any,
+        arg4: any,
+        arg5: any,
         event?: IpcEvent,
-      ): void;
+      ): Promise<any> | void;
     };
 export type Options = { maxTimeoutMs?: number };
 // There's an `any` here it's the only way that the typescript compiler allows you to call listener(...dataArgs, event).


### PR DESCRIPTION
This allows to actually use this package with typescript, otherwise I receive an error with the following code:

```ts
promiseIpc.on('sample-event', (url: string, pos: string, country: string) => {
        return new Promise((resolve, reject) => resolve(true));
});
```

error is:

> Argument of type '(url: string, pos: string, country: string) => Promise<void | object>' is not assignable to parameter of type 'Listener'.
>   Type '(url: string, pos: string, country: string) => Promise<void | object>' is not assignable to type '(event?: IpcEvent | undefined) => void'